### PR TITLE
Handle filters with missing arguments

### DIFF
--- a/pika_psql.go
+++ b/pika_psql.go
@@ -321,6 +321,9 @@ func (b *basePsql[T]) GetOrNil() (*T, error) {
 	}
 
 	q, args := b.GetOrNilQuery()
+	if b.err != nil {
+		return nil, b.err
+	}
 
 	// Execute query
 	var x T
@@ -778,6 +781,9 @@ func (b *basePsql[T]) filterStatement() (string, []any) {
 					if _, ok := b.args.Get(noWildcard[1:]); ok {
 						// If mapping found, replace with numbered parameter
 						v = fmt.Sprintf("$%d", mapping[noWildcard[1:]])
+					} else {
+						b.err = fmt.Errorf("missing argument: %s", noWildcard)
+						return "", nil
 					}
 				}
 				andOr := "AND"

--- a/pika_psql_test.go
+++ b/pika_psql_test.go
@@ -1658,3 +1658,33 @@ func TestJoinCount(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, ret)
 }
+
+func TestFilterMissingArgs(t *testing.T) {
+	psql := newPsql(t)
+	qs := Q[simpleModel1](psql)
+	args := NewArgs()
+
+	qs = qs.Filter("id=:id").Args(args)
+
+	requireError := func(err error) {
+		require.NotNil(t, err)
+		require.NotContains(t, err.Error(), "syntax")
+		require.Contains(t, err.Error(), "missing argument")
+	}
+
+	ret, err := qs.GetOrNil()
+	require.Nil(t, ret)
+	requireError(err)
+
+	_, err = qs.Get()
+	requireError(err)
+
+	err = qs.Delete()
+	requireError(err)
+
+	_, err = qs.All()
+	requireError(err)
+
+	_, err = qs.Count()
+	requireError(err)
+}


### PR DESCRIPTION
Currently, if the user provides a filter string using a named argument, but fails to include the argument in the "args" map, Pika will build and attempt to execute the query anyway, resulting in a native SQL syntax error which does not do a good job of telling the user what happened.

We should be able to detect a broken query before sending it to the database engine.