### PR TITLE
add ON CONFLICT DO NOTHING for insert

### DIFF
--- a/pika.go
+++ b/pika.go
@@ -85,7 +85,7 @@ type QuerySet[T any] interface {
 	ClearAll() QuerySet[T]
 
 	// Create creates a new value
-	Create(value *T) error
+	Create(value *T, options ...CreateOption) error
 
 	// Update updates a value
 	// All filters will be applied
@@ -130,7 +130,7 @@ type QuerySet[T any] interface {
 	// Query related methods
 
 	// CreateQuery returns the query and args for Create
-	CreateQuery(value *T) (string, []interface{})
+	CreateQuery(value *T, options ...CreateOption) (string, []interface{})
 
 	// UpdateQuery returns the query and args for Update
 	UpdateQuery(value *T) (string, []interface{})


### PR DESCRIPTION
in this PR, I added a new method named `CreateIgnore`, which will add `ON CONFLICT DO NOTHING` to `INSERT` query (https://www.postgresql.org/docs/current/sql-insert.html), it'll help avoid returning the duplicated key violation error thus application does not need to do this check at each place where `Create` method is called. 